### PR TITLE
try to fix order of items in calendars.json

### DIFF
--- a/scripts/generate-ics.mjs
+++ b/scripts/generate-ics.mjs
@@ -121,7 +121,7 @@ function  generateIcss(list, type) {
   }
   record(config.data, type, { //add itemList (les profs, les cours...) to config
     name: type,
-    items
+    items: Object.fromEntries(Object.entries(items).sort()) // this is dirty, definitely not future-proof (trying to impose an order on key-value pairs in an object is obviously stupid)
     })
   
 }


### PR DESCRIPTION
quand on navigue avec shift-flèche l'ordre n'est pas correct.
ce patch devrait arranger cela (de la pire des manières?)